### PR TITLE
.g/w/ubuntu.yml: Use the C.UTF-8 locale

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -4,6 +4,7 @@ on: [push]
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
+  LC_ALL: C.UTF-8
 
 jobs:
   build:

--- a/examples/documentation/quick/setup/CMakeLists.txt
+++ b/examples/documentation/quick/setup/CMakeLists.txt
@@ -63,5 +63,5 @@ target_link_libraries(my_app PRIVATE ztd::cuneicode)
 
 if (ZTD_CUNEICODE_TESTS)
 	add_test(NAME ztd.cuneicode.examples.documentation.quick.my_app
-		COMMAND my_app "Harold")
+		COMMAND my_app "Hárold")
 endif()


### PR DESCRIPTION
glibc has always been stubborn when it comes to what encoding the "C" locale uses. Tell it to stop doing ASCII so the tests may be less dumbed down.

Ref-URL: https://sourceware.org/glibc/wiki/Proposals/C.UTF-8