### PR TITLE
remove __c32_state alignment definition

### DIFF
--- a/source/include/ztd/cuneicode/detail/basic_conv.hpp
+++ b/source/include/ztd/cuneicode/detail/basic_conv.hpp
@@ -52,7 +52,7 @@ namespace cnc {
 		inline constexpr bool __least64_bit_pointers   = __wchar_t_pointer_size >= 64;
 		inline constexpr bool __least32_bit_pointers   = __wchar_t_pointer_size >= 32;
 
-		struct alignas(ztd_mbstate_t) __c32_state {
+		struct __c32_state {
 			ztd_char32_t __accumulation : 32;
 			unsigned char __accumulation_count : 8;
 			unsigned char __expected_count : 8;


### PR DESCRIPTION
before apply fix,  vcpkg ci error log
[install-x64-android-dbg-out.log](https://github.com/soasis/cuneicode/files/13204154/install-x64-android-dbg-out.log)
