### PR TITLE
Don't refer to nonexistent target.

### DIFF
--- a/cmake/ztd.cuneicode-config.cmake.in
+++ b/cmake/ztd.cuneicode-config.cmake.in
@@ -2,7 +2,7 @@
 
 if (TARGET ztd::cuneicode)
 	get_target_property(ZTD_CUNEICODE_INCLUDE_DIRS
-		ztd.cuneicode.single INTERFACE_INCLUDE_DIRECTORIES)
+		ztd.cuneicode INTERFACE_INCLUDE_DIRECTORIES)
 	set_and_check(ZTD_CUNEICODE_INCLUDE_DIRS "${ZTD_CUNEICODE_INCLUDE_DIRS}")
 endif()
 


### PR DESCRIPTION
get_target_property was being given ztd::cuneicode::single even when that target does not exist.